### PR TITLE
Passes `promptIsSelectable` through to the one-way control component.

### DIFF
--- a/app/templates/components/mediasuite-select-box.hbs
+++ b/app/templates/components/mediasuite-select-box.hbs
@@ -7,6 +7,7 @@
   update=update
   disabled=disabled
   prompt=prompt
+  promptIsSelectable=promptIsSelectable
   optionValuePath=optionValuePath
   optionLabelPath=optionLabelPath
 }}

--- a/tests/dummy/app/templates/select-box.hbs
+++ b/tests/dummy/app/templates/select-box.hbs
@@ -21,6 +21,7 @@
     <tr><td>label</td><td>string</td><td>Label</td></tr>
     <tr><td>didChange</td><td>closure function (selected(object), component(object))</td><td>Fires when the drop-down value changes</td></tr>
     <tr><td>prompt</td><td>string</td><td>Option to add placeholder text as the first option</td></tr>
+    <tr><td>promptIsSelectable</td><td>boolean (default false)</td><td>Whether the placeholder text is selectable</td></tr>
     <tr><td>optionValuePath</td><td>string</td><td>If your options are objects, this is the path to the value on each option</td></tr>
     <tr><td>optionLabelPath</td><td>string</td><td>If your options are objects, this is the path to the display text for each option</td></tr>
     <tr><td>multiple</td><td>boolean (default false)</td><td>Whether you want a multi-select.  The wrapping div will have a 'multiple' class,


### PR DESCRIPTION
Allows the placeholder text to be selected.
