### PR TITLE
added keyEvents to mediasuite-input template

### DIFF
--- a/app/templates/components/mediasuite-input.hbs
+++ b/app/templates/components/mediasuite-input.hbs
@@ -10,6 +10,7 @@
   class=class
   disabled=disabled
   update=update
+  keyEvents=keyEvents
 }}
 {{#each errors as |error|}}
   <span class="error">{{error.message}}</span>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mediasuite-formelements",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "The default blueprint for ember-cli addons.",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
Added keyEvents to template, as is present in ember-oneway-input, but not here.